### PR TITLE
linux: removed kernel-package dependency

### DIFF
--- a/Linux/docker/Dockerfile.i386
+++ b/Linux/docker/Dockerfile.i386
@@ -26,12 +26,12 @@ FROM 32bit/debian
 
 MAINTAINER Vitaly Chipounov <vitaly@cyberhaven.io>
 
-RUN \
-    apt-get update && \
-    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
-    sudo apt-file texinfo flex bison patch python unzip git bc \
-    bzip2 wget less nano g++ gcc file libc6-dev  make \
-    fakeroot build-essential devscripts kernel-package libncurses5-dev && \
+RUN                                                                             \
+    apt-get update &&                                                           \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends   \
+    sudo apt-file texinfo flex bison patch python unzip git bc                  \
+    bzip2 wget less nano g++ gcc file libc6-dev make                            \
+    fakeroot build-essential devscripts libncurses5-dev &&                      \
     apt-get clean && \
     apt-file update
 

--- a/Linux/docker/Dockerfile.x86_64
+++ b/Linux/docker/Dockerfile.x86_64
@@ -26,13 +26,13 @@ FROM debian
 
 MAINTAINER Vitaly Chipounov <vitaly@cyberhaven.io>
 
-RUN \
-    apt-get update && \
-    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
-    sudo apt-file texinfo flex bison patch python unzip git bc \
-    bzip2 wget less nano g++ gcc file libc6-dev  make \
-    fakeroot build-essential devscripts kernel-package libncurses5-dev && \
-    apt-get clean && \
+RUN                                                                             \
+    apt-get update &&                                                           \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends   \
+    sudo apt-file texinfo flex bison patch python unzip git bc                  \
+    bzip2 wget less nano g++ gcc file libc6-dev make                            \
+    fakeroot build-essential devscripts libncurses5-dev &&                      \
+    apt-get clean &&                                                            \
     apt-file update
 
 

--- a/Linux/docker/make-kernel.sh
+++ b/Linux/docker/make-kernel.sh
@@ -66,9 +66,8 @@ else
     echo "Using existing .config"
 fi
 
-
 # NOTE: you have to run this inside special docker image (see run-docker.sh)
-make-kpkg --initrd --append-to-version s2e --jobs 8 --rootcmd fakeroot  kernel-image kernel-debug || err "Build failed"
+fakeroot make -j8 deb-pkg LOCALVERSION=-s2e || err "Build failed"
 
 # Restore access to files under version control
 chmod a+rw debian


### PR DESCRIPTION
`kernel-package` is not available in the current Debian stable, "Stretch", (see https://lists.debian.org/debian-user/2017/06/msg00774.html). Even though there are fixes around this, make-kpkg has been deprecated for some time.

Rather than sticking to deprecated build process, I've updated to the current recommended process, as described at https://kernel-handbook.alioth.debian.org/ch-common-tasks.html#s-common-building

I've tested both Linux images and the CGC image. This is currently blocking the build of x86_64 Linux images.