### PR TITLE
module: Deactivated Windows Defender.

### DIFF
--- a/Windows/install_scripts/06-configure.bat
+++ b/Windows/install_scripts/06-configure.bat
@@ -37,6 +37,12 @@ reg add "HKLM\Software\Microsoft\Windows\CurrentVersion\Policies\Explorer" /v Hi
 echo ==^> Disabling Windows Security service
 sc config wscsvc start= disabled
 
+echo ==^> Disabling Windows Defender
+reg ADD "HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows Defender" /v DisableAntiSpyware /t REG_DWORD /d 0x1 /f
+
+echo ==^> Disabling Windows Defender Realtime Protection
+reg ADD "HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows Defender\Real-Time Protection" /v DisableRealtimeMonitoring /t REG_DWORD /d 0x1 /f
+
 echo ==^> Turning off driver signature enforcement (test signing)
 Bcdedit.exe -set TESTSIGNING ON
 

--- a/Windows/install_scripts/disable_windefend.reg
+++ b/Windows/install_scripts/disable_windefend.reg
@@ -1,2 +1,0 @@
-[HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows Defender]
-"DisableAntiSpyware"=dword:00000001


### PR DESCRIPTION
Normally the disable_windefend.reg should set a registry key, such that Windows Defender is deactivated. However although the file seems to be executed, this had no effect. I therefore added the relevant commands to 06-configure.bat to set the keys accordingly.

Signed-off-by: Sebastian Walla <sebastian.walla@gmx.de>