### PR TITLE
Improvement/image descriptor

### DIFF
--- a/images.json
+++ b/images.json
@@ -1,5 +1,5 @@
 {
-  "version": 2,
+  "version": 3,
   "images": {
     "debian-9.2.1-i386": {
       "name": "Debian i386 image",


### PR DESCRIPTION
I was poking around in s2e-env's jinja templates and noticed that there were a bunch of missing/incorrect key/value pairs being passed during project creation.

One of these was the `image_group`, which s2e-env was expecting to find in the image descriptor under `$S2EDIR/images/<IMAGE>/image.json`. However, this wasn't being copied across when creating an image, so I've updated the Python script to do so.

My understanding is this also necessitates a version bump. Let me know if this is wrong.