### PR TITLE
images.json: update outdated ubuntu iso url

### DIFF
--- a/images.json
+++ b/images.json
@@ -6,7 +6,7 @@
       "image_group": "linux",
       "url": "https://drive.google.com/open?id=102EgrujJE5Pzlg98qe3twLNIeMz5MkJQ",
       "iso": {
-        "url": "https://releases.ubuntu.com/22.04/ubuntu-22.04-live-server-amd64.iso"
+        "url": "https://old-releases.ubuntu.com/releases/jammy/ubuntu-22.04-live-server-amd64.iso"
       },
       "os": {
         "name": "ubuntu",


### PR DESCRIPTION
The link of "ubuntu-22.04-desktop-amd64.iso" is updated when there is new version of ubuntu, and now it has became https://releases.ubuntu.com/22.04/ubuntu-22.04.1-desktop-amd64.iso.

Although I update the link to make sure command "s2e image_build ubuntu-22.04-x86_64" works, I think this is not a perfect solution.