### PR TITLE
linux: update ubuntu iso url to 22.04.3

### DIFF
--- a/images.json
+++ b/images.json
@@ -6,7 +6,7 @@
       "image_group": "linux",
       "url": "https://drive.google.com/open?id=102EgrujJE5Pzlg98qe3twLNIeMz5MkJQ",
       "iso": {
-        "url": "https://releases.ubuntu.com/22.04/ubuntu-22.04.2-live-server-amd64.iso"
+        "url": "https://releases.ubuntu.com/22.04/ubuntu-22.04.3-live-server-amd64.iso"
       },
       "os": {
         "name": "ubuntu",


### PR DESCRIPTION
The Ubuntu ISO URL is updated, as the old link (https://releases.ubuntu.com/22.04/ubuntu-22.04.2-live-server-amd64.iso) isn't valid anymore and leads a 404 error while building the image.